### PR TITLE
Fix Problem libs

### DIFF
--- a/files/install.sh
+++ b/files/install.sh
@@ -80,11 +80,11 @@ install_dependencies() {
     if [ "$kernel" = "Linux" ]; then
         . /etc/os-release
         declare -A command_by_ID=(
-            ["arch"]="pacman -S --noconfirm --needed ipset "
-            ["artix"]="pacman -S --noconfirm --needed ipset "
-            ["cachyos"]="pacman -S --noconfirm --needed ipset "
-            ["endeavouros"]="pacman -S --noconfirm --needed ipset "
-            ["manjaro"]="pacman -S --noconfirm --needed ipset "
+            ["arch"]="pacman -S --noconfirm --needed ipset libnetfilter_queue libnfnetlink libmnl"
+            ["artix"]="pacman -S --noconfirm --needed ipset libnetfilter_queue libnfnetlink libmnl"
+            ["cachyos"]="pacman -S --noconfirm --needed ipset libnetfilter_queue libnfnetlink libmnl"
+            ["endeavouros"]="pacman -S --noconfirm --needed ipset libnetfilter_queue libnfnetlink libmnl"
+            ["manjaro"]="pacman -S --noconfirm --needed ipset libnetfilter_queue libnfnetlink libmnl"
             ["debian"]="apt-get install -y iptables ipset "
             ["fedora"]="dnf install -y iptables ipset"
             ["ubuntu"]="apt-get install -y iptables ipset"


### PR DESCRIPTION
## Короч как я те писал что если данных либ нет , то если ставить его с гита (запрет) будет такое

---

```
make[1]: выход из каталога «/opt/zapret/mdig»
make[1]: вход в каталог «/opt/zapret/nfq»
cc -s -march=native  -std=gnu99 -O2 -flto=auto -DUSE_SYSTEMD -o nfqws *.c crypto/*.c -lz -lnetfilter_queue -lnfnetlink -lmnl -lsystemd 
helpers.c: В функции «pton4_port»:
helpers.c:228:11: предупреждение: присваивание отменяет квалификатор «const» указуемого типа [-Wdiscarded-qualifiers]
  228 |         p = strchr(s,':');
      |           ^
helpers.c: В функции «pton6_port»:
helpers.c:249:11: предупреждение: присваивание отменяет квалификатор «const» указуемого типа [-Wdiscarded-qualifiers]
  249 |         p = strchr(s,']');
      |           ^
nfqws.c:44:10: фатальная ошибка: libnetfilter_queue/libnetfilter_queue.h: Нет такого файла или каталога
   44 | #include <libnetfilter_queue/libnetfilter_queue.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
компиляция прервана.
make[1]: *** [Makefile:24: systemd] Ошибка 1
make[1]: выход из каталога «/opt/zapret/nfq»
make: *** [Makefile:19: systemd] Ошибка 2
make: выход из каталога «/opt/zapret»
could not compile
make: вход в каталог «/opt/zapret»
make[1]: вход в каталог «/opt/zapret/nfq»
rm -f nfqws dvtws winws.exe
make[1]: выход из каталога «/opt/zapret/nfq»
make[1]: вход в каталог «/opt/zapret/tpws»
rm -f tpws *.o
make[1]: выход из каталога «/opt/zapret/tpws»
make[1]: вход в каталог «/opt/zapret/ip2net»
rm -f ip2net *.o
make[1]: выход из каталога «/opt/zapret/ip2net»
make[1]: вход в каталог «/opt/zapret/mdig»
rm -f mdig *.o
make[1]: выход из каталога «/opt/zapret/mdig»
make: выход из каталога «/opt/zapret»

press enter to continue
```
Я пофиксил добавив нужные пакеты